### PR TITLE
fix: endpointが指定されていないときの修正

### DIFF
--- a/internal/infra/db/dynamodb_client.go
+++ b/internal/infra/db/dynamodb_client.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,10 +13,10 @@ type DynamoDBClient struct {
 	Client *dynamodb.DynamoDB
 }
 
-func DynamoDBClientRequest() *DynamoDBClient {
+func DynamoDBClientRequest() (*DynamoDBClient, error) {
 	endpoint := os.Getenv("DYNAMODB_ENDPOINT")
 	if endpoint == "" {
-		endpoint = "http://localhost:8000" // デフォルトエンドポイント
+		return nil, fmt.Errorf("DYNAMODB_ENDPOINT is not set")
 	}
 	sess := session.Must(session.NewSession(&aws.Config{
 		Region:   aws.String("ap-northeast-1"),
@@ -23,5 +24,5 @@ func DynamoDBClientRequest() *DynamoDBClient {
 	}))
 	return &DynamoDBClient{
 		Client: dynamodb.New(sess),
-	}
+	}, nil
 }

--- a/main/main.go
+++ b/main/main.go
@@ -12,7 +12,10 @@ import (
 )
 
 func main() {
-	dynamoClient := db.DynamoDBClientRequest()
+	dynamoClient, err := db.DynamoDBClientRequest()
+	if err != nil {
+		panic(err)
+	}
 	calendarRepo := repository.CalendarRepositoryRequest(dynamoClient)
 	eventRepo := repository.EventRepositoryRequest(dynamoClient)
 	appUsecase := usecase.CalendarUsecaseRequest(calendarRepo, eventRepo)


### PR DESCRIPTION
## 実装の目的/背景
<!-- なんのためのPRかわかるように記載 -->
- dynamoDBの指定がなかった時をエラーにする
## 要件・仕様
<!-- Issuesに記載されたもので構わないので、こちらにも記載してください -->
- エンドポイントが指定されていないときはエラーで返却

## 特記 / 特にレビューしてほしい箇所
- errorにするのかnilのまま進めるべきかで、errorとして終了するようにしたけどどうですかね
- errorの時は基本小文字から始める、とあったけど、DYNAMODB_ENDPOINTっていう環境変数だから大文字のままにしました
<!-- 複雑な処理が含まれる場合は、設計・実装方針を記載してください
※ コードにコメントと言う形での記載も可 -->

<!-- 特にレビューしてほしい箇所があればここに書いてください　-->

## 動作確認
```template.yaml```からDYNAMODB_ENDPOINTを消して以下を実行
```
curl -X GET "http://localhost:3000/dynamodb-test"
{"message":"Internal server error"}
```
```
panic: DYNAMODB_ENDPOINT is not set
```
<!-- 基本的には、動作確認はmustでお願いします-->

<!-- 動作確認が未実施の場合はその理由を書いてください。もしくは、今後動作確認実施予定がある場合はその旨を記載して下さい -->

## Issues番号
https://github.com/Teamsasa/Bonded/issues/30