### PR TITLE
feat: implement user repository and update calendar creation logic

### DIFF
--- a/internal/handler/calendar_impl.go
+++ b/internal/handler/calendar_impl.go
@@ -55,7 +55,7 @@ func (h *Handler) HandleGetCalendars(ctx context.Context, request events.APIGate
 }
 
 func (h *Handler) HandleCreateCalendar(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	var calendar models.Calendar
+	var calendar models.CreateCalendar
 	err := json.Unmarshal([]byte(request.Body), &calendar)
 	if err != nil {
 		return events.APIGatewayProxyResponse{
@@ -72,16 +72,6 @@ func (h *Handler) HandleCreateCalendar(ctx context.Context, request events.APIGa
 	}
 	userID := request.PathParameters["userId"]
 	calendar.OwnerUserID = userID
-
-	// ユーザー情報を内部的に取得 送るべき？
-	user := models.User{
-		UserID:      userID,
-		DisplayName: "Owner",
-		Email:       userID + "@example.com",
-		Password:    "password",
-		AccessLevel: "OWNER",
-	}
-	calendar.Users = []models.User{user}
 
 	err = h.CalendarUsecase.CreateCalendar(ctx, &calendar)
 	if err != nil {

--- a/internal/handler/interfaces.go
+++ b/internal/handler/interfaces.go
@@ -28,4 +28,3 @@ func (h *Handler) HelloHandler(ctx context.Context, request events.APIGatewayPro
 		StatusCode: 200,
 	}, nil
 }
-

--- a/internal/handler/interfaces.go
+++ b/internal/handler/interfaces.go
@@ -14,9 +14,8 @@ type Handler struct {
 	EventUsecase    usecase.EventUsecase
 }
 
-func HandlerRequest(repo repository.CalendarRepository, usecase usecase.Usecase) *Handler {
+func HandlerRequest(usecase usecase.Usecase) *Handler {
 	return &Handler{
-		Repo:            repo,
 		CalendarUsecase: usecase.Calendar(),
 		EventUsecase:    usecase.Event(),
 	}

--- a/internal/models/calendar.go
+++ b/internal/models/calendar.go
@@ -9,3 +9,14 @@ type Calendar struct {
 	Users       []User  `json:"users,omitempty" dynamodbav:"Users"`             // 共有ユーザーのIDリスト
 	Events      []Event `json:"events,omitempty"`                               // カレンダー内のイベント
 }
+
+type CreateCalendar struct {
+	CalendarID  string  `json:"calendarId,omitempty" dynamodbav:"CalendarID"`   // カレンダーのID
+	SortKey     string  `json:"sortKey,omitempty" dynamodbav:"SortKey"`         // ソートキー
+	Name        string  `json:"name" dynamodbav:"Name"`                         // カレンダー名
+	IsPublic    *bool   `json:"isPublic" dynamodbav:"IsPublic"`                 // 公開フラグ
+	OwnerUserID string  `json:"ownerUserId,omitempty" dynamodbav:"OwnerUserID"` // オーナーのユーザーID
+	OwnerName   string  `json:"ownerName,omitempty" dynamodbav:"OwnerName"`     // オーナーのユーザー名
+	Users       []User  `json:"users,omitempty" dynamodbav:"Users"`             // 共有ユーザーのIDリスト
+	Events      []Event `json:"events,omitempty"`                               // カレンダー内のイベント
+}

--- a/internal/repository/calendar_impl.go
+++ b/internal/repository/calendar_impl.go
@@ -11,6 +11,7 @@ import (
 )
 
 func (r *calendarRepository) Create(ctx context.Context, calendar *models.Calendar) error {
+	fmt.Println(calendar.Users[0].DisplayName)
 	item, err := dynamodbattribute.MarshalMap(calendar)
 	if err != nil {
 		return err

--- a/internal/repository/calendar_impl.go
+++ b/internal/repository/calendar_impl.go
@@ -28,9 +28,6 @@ func (r *calendarRepository) Create(ctx context.Context, calendar *models.Calend
 		TableName: aws.String(r.tableName),
 		Item:      relatedItem,
 	}
-
-	fmt.Println("Inserted Related item:\n", relatedItem)
-
 	_, err := r.dynamoDB.PutItemWithContext(ctx, relatedInput)
 	if err != nil {
 		return err
@@ -59,8 +56,6 @@ func (r *calendarRepository) Create(ctx context.Context, calendar *models.Calend
 		TableName: aws.String(r.tableName),
 		Item:      mainItem,
 	}
-
-	fmt.Println("Inserted Calendar item:\n", mainItem)
 
 	_, err = r.dynamoDB.PutItemWithContext(ctx, mainInput)
 	if err != nil {
@@ -96,9 +91,6 @@ func (r *calendarRepository) Create(ctx context.Context, calendar *models.Calend
 		TableName: aws.String(r.tableName),
 		Item:      userItem,
 	}
-
-	fmt.Println("Inserted User item:\n", userItem)
-
 	_, err = r.dynamoDB.PutItemWithContext(ctx, userInput)
 	if err != nil {
 		return err
@@ -245,9 +237,6 @@ func (r *calendarRepository) FindByUserID(ctx context.Context, userID string) ([
 			calendars = append(calendars, calendar)
 			calendarIDSet[calendarID] = struct{}{}
 		}
-	}
-	for _, calendar := range calendars {
-		fmt.Printf("CalendarID: %s, Users: %+v\n", calendar.CalendarID, calendar.Users)
 	}
 
 	return calendars, nil

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"bonded/internal/infra/db"
 	"bonded/internal/models"
 	"context"
+
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
@@ -41,4 +42,20 @@ type CalendarRepository interface {
 
 type EventRepository interface {
 	CreateEvent(ctx context.Context, calendar *models.Calendar, event *models.Event) error
+}
+
+type userRepository struct {
+	dynamoDB  *dynamodb.DynamoDB
+	tableName string
+}
+
+func UserRepositoryRequest(dynamoClient *db.DynamoDBClient) UserRepository {
+	return &userRepository{
+		dynamoDB:  dynamoClient.Client,
+		tableName: "Calendars",
+	}
+}
+
+type UserRepository interface {
+	FindByUserID(ctx context.Context, userID string) (*models.User, error)
 }

--- a/internal/repository/user_impl.go
+++ b/internal/repository/user_impl.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"bonded/internal/models"
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+func (r *userRepository) FindByUserID(ctx context.Context, userID string) (*models.User, error) {
+	input := &dynamodb.QueryInput{
+		TableName:              aws.String(r.tableName),
+		IndexName:              aws.String("UserID-index"),
+		KeyConditionExpression: aws.String("UserID = :uid"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":uid": {S: aws.String(userID)},
+		},
+	}
+
+	result, err := r.dynamoDB.QueryWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Items) == 0 {
+		return nil, fmt.Errorf("user with UserID %s not found", userID)
+	}
+
+	var users []models.User
+	err = dynamodbattribute.UnmarshalListOfMaps(result.Items, &users)
+	if err != nil {
+		return nil, err
+	}
+
+	// 最初の要素をユーザーの名前とする
+	user := users[0]
+	return &user, nil
+}

--- a/internal/usecase/calendar_impl.go
+++ b/internal/usecase/calendar_impl.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"bonded/internal/models"
 	"context"
+
 	"github.com/google/uuid"
 )
 
@@ -10,9 +11,37 @@ func (u *calendarUsecase) FindCalendar(ctx context.Context, calendarID string) (
 	return u.calendarRepo.FindByCalendarID(ctx, calendarID)
 }
 
-func (u *calendarUsecase) CreateCalendar(ctx context.Context, calendar *models.Calendar) error {
+func (u *calendarUsecase) CreateCalendar(ctx context.Context, calendar *models.CreateCalendar) error {
+	if calendar.OwnerName == "" {
+		user, err := u.userRepo.FindByUserID(ctx, calendar.OwnerUserID)
+		if err != nil {
+			return err
+		}
+		calendar.OwnerName = user.DisplayName
+	}
+	user := models.User{
+		UserID:      calendar.OwnerUserID,
+		DisplayName: calendar.OwnerName,
+		Email:       calendar.OwnerUserID + "@example.com",
+		Password:    "password",
+		AccessLevel: "OWNER",
+	}
+	calendar.Users = []models.User{user}
+
 	calendar.CalendarID = uuid.New().String()
-	return u.calendarRepo.Create(ctx, calendar)
+
+	// CreateCalendarのフィールドをCalendarに変換
+	calendarReq := models.Calendar{
+		CalendarID:  calendar.CalendarID,
+		SortKey:     "CALENDAR",
+		Name:        calendar.Name,
+		IsPublic:    calendar.IsPublic,
+		OwnerUserID: calendar.OwnerUserID,
+		Users:       calendar.Users,
+		Events:      calendar.Events,
+	}
+
+	return u.calendarRepo.Create(ctx, &calendarReq)
 }
 
 func (u *calendarUsecase) EditCalendar(ctx context.Context, calendar *models.Calendar, input *models.Calendar) error {

--- a/internal/usecase/interfaces.go
+++ b/internal/usecase/interfaces.go
@@ -6,10 +6,11 @@ import (
 	"context"
 )
 
-func CalendarUsecaseRequest(calendarRepo repository.CalendarRepository, eventRepo repository.EventRepository) Usecase {
+func CalendarUsecaseRequest(calendarRepo repository.CalendarRepository, eventRepo repository.EventRepository, userRepo repository.UserRepository) Usecase {
 	return &usecase{
 		calendarUsecase: &calendarUsecase{
 			calendarRepo: calendarRepo,
+			userRepo:     userRepo,
 		},
 		eventUsecase: &eventUsecase{
 			eventRepo: eventRepo,
@@ -24,6 +25,7 @@ type usecase struct {
 
 type calendarUsecase struct {
 	calendarRepo repository.CalendarRepository
+	userRepo     repository.UserRepository
 }
 
 type eventUsecase struct {
@@ -44,7 +46,7 @@ func (u *usecase) Event() EventUsecase {
 }
 
 type CalendarUsecase interface {
-	CreateCalendar(ctx context.Context, calendar *models.Calendar) error
+	CreateCalendar(ctx context.Context, calendar *models.CreateCalendar) error
 	EditCalendar(ctx context.Context, calendar *models.Calendar, input *models.Calendar) error
 	DeleteCalendar(ctx context.Context, calendarID string) error
 	FindCalendars(ctx context.Context, userID string) ([]*models.Calendar, error)

--- a/main/main.go
+++ b/main/main.go
@@ -31,10 +31,11 @@ func main() {
 	dynamoClient := db.DynamoDBClientRequest()
 	calendarRepo := repository.CalendarRepositoryRequest(dynamoClient)
 	eventRepo := repository.EventRepositoryRequest(dynamoClient)
-	caredarUsecase := usecase.CalendarUsecaseRequest(calendarRepo, eventRepo)
+	userRepo := repository.UserRepositoryRequest(dynamoClient)
+	caledarUsecase := usecase.CalendarUsecaseRequest(calendarRepo, eventRepo, userRepo)
 	authUsecase := usecase.NewAuthUsecase(jwks, clientID, cognitoIssuer)
 	middleware := middleware.NewAuthMiddleware(authUsecase)
-	h := handler.HandlerRequest(calendarRepo, caredarUsecase)
+	h := handler.HandlerRequest(caledarUsecase)
 
 	lambda.Start(func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		authenticatedHandler := middleware.AuthMiddleware(func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {


### PR DESCRIPTION
## 実装の目的/背景

- 新規ユーザー以外のカレンダー作成時にuserIdからusernameを検索して入れたい

## 要件・仕様

- bodyにownerNameが指定された場合は、その名前でusersがOWNERとして作成される
- 入っていない場合、前述の通り検索して格納する

## やったこと

- 要件・仕様の実装
- mainでhandlerにrepoが入っているのを修正
- カレンダーを作る際に、handlerでusersの情報を作成していたが、これをusecaseに移動

## 特記 / 特にレビューしてほしい箇所

- とくなし

## 動作確認

名前の検索機能はうまく動いているようですが、そもそもcalendarの作成時にusersとeventsが作成出来ていないようで、全体を通しての動作確認は出来ていません。
