### PR TITLE
存在していないAPIにリクエストを送信した際に403になる問題を修正

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -34,53 +34,11 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: "Events"
       Events:
-        Calendar:
-          Type: Api
-          Properties: 
-            Path: /calendar/{calendarId}
-            Method: GET
-            RestApiId: !Ref BondedApi
-        CalendarList:
+        ProxyResource:
           Type: Api
           Properties:
-            Path: /calendar/list/{userId}
-            Method: GET
-            RestApiId: !Ref BondedApi
-        CalendarCreate:
-          Type: Api
-          Properties:
-            Path: /calendar/create/{userId}
-            Method: POST
-            RestApiId: !Ref BondedApi
-        CalendarEdit:
-          Type: Api
-          Properties:
-            Path: /calendar/edit/{calendarId}
-            Method: PUT
-            RestApiId: !Ref BondedApi
-        Hello:
-          Type: Api
-          Properties:
-            Path: /hello
-            Method: GET
-            RestApiId: !Ref BondedApi
-        DynamoDBTest:
-          Type: Api
-          Properties:
-            Path: /dynamodb-test
-            Method: GET
-            RestApiId: !Ref BondedApi
-        CalendarDelete:
-          Type: Api
-          Properties:
-            Path: /calendar/delete/{calendarId}
-            Method: DELETE
-            RestApiId: !Ref BondedApi
-        EventCreate:
-          Type: Api
-          Properties:
-            Path: /event/create/{calendarId}
-            Method: POST
+            Path: /{proxy+}
+            Method: ANY
             RestApiId: !Ref BondedApi
 
     Metadata:


### PR DESCRIPTION
## 実装の目的/背景
<!-- なんのためのPRかわかるように記載 -->
- 存在していないAPIにリクエストを送信した際に403になる問題を修正
## 要件・仕様
<!-- Issuesに記載されたもので構わないので、こちらにも記載してください -->
- 存在していないエンドポイントを叩いた際は`main.go`で404を返しているはずだがなぜか`"message": "Missing Authentication Token"`が返却される
https://github.com/Teamsasa/Bonded/blob/641af4d45ef3befdfbcb25c3bef381fbd6b21a7b/main/main.go#L72-L75
- 原因の調査と改善を行う
## やったこと
<!-- やったことを簡潔に記載 -->

このプルリクエストでは、API構成に大幅な変更を加えており、特にtemplate.yamlファイル内のEventsリソースに関連した変更が含まれています。主な変更点として、複数の個別APIエンドポイントを単一のプロキシリソースに置き換えました。

### API構成の変更

- [template.yaml](diffhunk://#diff-1363ef5ce8886100842332c97163aad7934237e1fe49b5d40422b45fdc30f38eL37-R41): 以下のような複数の特定APIエンドポイント
```
/calendar/{calendarId}
/calendar/list/{userId}
/calendar/create/{userId}
/calendar/edit/{calendarId}
/hello
/dynamodb-test
/calendar/delete/{calendarId}
/event/create/{calendarId}
```
を削除し、単一のプロキシリソース (/{proxy+}) に置き換えました。このプロキシリソースは任意のHTTPメソッドをサポートしており、API構成を簡略化するとともに、柔軟なルーティングを可能にします。

### 原因
- API Gatewayがそのエンドポイントを認識しておらず、GOのコードに辿り着く前に`template.yaml`で弾いていたから
### 改善方法
- `template.yaml`では全てのリクエストを通し、サーバー側で取捨選択する
## 特記 / 特にレビューしてほしい箇所
- 正直どちらでもいいと思う
- AWSの思想に沿うなら既存のコードが仕様通りの実装な気がするが...
- 変更を加えたほうが開発はやりやすい
- あとちゃんと404が返却される
<!-- 複雑な処理が含まれる場合は、設計・実装方針を記載してください
※ コードにコメントと言う形での記載も可 -->

<!-- 特にレビューしてほしい箇所があればここに書いてください　-->

## 動作確認
- ローカルで検証ずみ
<!-- 基本的には、動作確認はmustでお願いします-->

<!-- 動作確認が未実施の場合はその理由を書いてください。もしくは、今後動作確認実施予定がある場合はその旨を記載して下さい -->

## Issues番号
- close #31 