### PR TITLE
指定されたエンドポイントで認証をスキップする機能の実装

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -18,16 +18,27 @@ type IAuthMiddleware interface {
 
 type authMiddleware struct {
 	authUsecase usecase.IAuthUsecase
+	publicPaths map[string]bool
 }
 
 func NewAuthMiddleware(authUsecase usecase.IAuthUsecase) IAuthMiddleware {
+	publicPaths := map[string]bool{
+		"/hello":                true,
+		"/calendar/list/public": true,
+	}
+
 	return &authMiddleware{
 		authUsecase: authUsecase,
+		publicPaths: publicPaths,
 	}
 }
 
 func (am *authMiddleware) AuthMiddleware(next func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)) func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		if am.publicPaths[request.Path] {
+			return next(ctx, request)
+		}
+
 		authHeader, ok := request.Headers["Authorization"]
 		if !ok || !strings.HasPrefix(authHeader, "Bearer ") {
 			return unauthorizedResponse("Missing or invalid Authorization header")


### PR DESCRIPTION
## 実装の目的/背景

- 一部のエンドポイントで認証を行っていない状態でも叩けるようにする

## 要件・仕様

指定されたエンドポイントで認証をスキップする機能の実装

## やったこと

- publicPathsに設定されたものは認証をスキップする処理を実装

## 特記 / 特にレビューしてほしい箇所

- 今publicPathsに設定されてるのはウルトラ適当に入れただけです特に意味はありません

## 動作確認

- 一応ローカルでは動いてます

## Issues番号

- solve #48 
