### PR TITLE
非公開カレンダー閲覧ブロック機能作成

### DIFF
--- a/internal/contextKey/ctxKey.go
+++ b/internal/contextKey/ctxKey.go
@@ -1,0 +1,5 @@
+package contextKey
+
+type ctxKey string
+
+const JwtDataKey ctxKey = "jwtData"

--- a/internal/contextKey/ctxKey.go
+++ b/internal/contextKey/ctxKey.go
@@ -1,5 +1,5 @@
 package contextKey
 
-type ctxKey string
+type ctxKey struct{}
 
-const JwtDataKey ctxKey = "jwtData"
+var JwtDataKey = ctxKey{}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,16 +1,13 @@
 package middleware
 
 import (
+	"bonded/internal/contextKey"
 	"bonded/internal/usecase"
 	"context"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 )
-
-type contextKey string
-
-const jwtDataKey contextKey = "jwtData"
 
 type IAuthMiddleware interface {
 	AuthMiddleware(next func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)) func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)
@@ -48,7 +45,7 @@ func (am *authMiddleware) AuthMiddleware(next func(ctx context.Context, request 
 			return unauthorizedResponse(err.Error())
 		}
 
-		ctx = context.WithValue(ctx, jwtDataKey, jwtData)
+		ctx = context.WithValue(ctx, contextKey.JwtDataKey, jwtData)
 
 		return next(ctx, request)
 	}


### PR DESCRIPTION
## 実装の目的/背景
<!-- なんのためのPRかわかるように記載 -->
- 非公開カレンダー閲覧ブロック機能作成
## 要件・仕様
<!-- Issuesに記載されたもので構わないので、こちらにも記載してください -->
- `http://127.0.0.1:3000/calendar/{calendarId}`を叩く際にUserにアクセス者が含まれていない場合はエラーを返す
## やったこと
<!-- やったことを簡潔に記載 -->
このプルリクエストでは、JWTデータのコンテキスト内での取り扱いを改善し、FindCalendar メソッドの機能を強化するためのいくつかの変更を含んでいます。主な変更点として、新しい contextKey パッケージの導入、このパッケージを活用したリファクタリング、さらに FindCalendar メソッドにユーザーアクセスを確認するロジックを追加しました。

### なぜ新規パッケージを追加したか

- Goのcontextパッケージでキーを扱う場合、同一キーとして扱われるには同じ変数インスタンスを共有する必要があるらしい
- つまり、同じ文字列、型でも別パッケージで定義していると別物とみなされる
- そのため、新規パッケージ内でキーを定義し、様々なパッケージで統一キーを利用できるように定義

### リファクタリングとコンテキストキーの取り扱い
- `internal/contextKey/ctxKey.go`: 新しい contextKey パッケージを導入し、JWTデータをコンテキスト内で管理するための ctxKey 型と定数 JwtDataKey を追加しました。
- `internal/middleware/middleware.go`: 新しい contextKey パッケージを利用してJWTデータを管理するようにリファクタリングし、これまで使用していたインライン定義のコンテキストキーを置き換えました。

### FindCalendar メソッドの強化
- internal/usecase/calendar_impl.go`: FindCalendar メソッドにロジックを追加し、カレンダーが公開設定かどうかを確認する処理を実装しました。非公開の場合、コンテキストからJWTデータを取得し、ユーザーがそのカレンダーに登録されているかを検証して、ユーザーアクセスを確認するようにしました。
## 特記 / 特にレビューしてほしい箇所
- なし
<!-- 複雑な処理が含まれる場合は、設計・実装方針を記載してください
※ コードにコメントと言う形での記載も可 -->

<!-- 特にレビューしてほしい箇所があればここに書いてください　-->

## 動作確認
- ローカルで動作確認済み
<!-- 基本的には、動作確認はmustでお願いします-->

<!-- 動作確認が未実施の場合はその理由を書いてください。もしくは、今後動作確認実施予定がある場合はその旨を記載して下さい -->

## Issues番号
- close #13 