### PR TITLE
カレンダー取得のAPIに認証をかけない

### DIFF
--- a/internal/handler/calendar_impl.go
+++ b/internal/handler/calendar_impl.go
@@ -12,10 +12,17 @@ import (
 func (h *Handler) HandleGetCalendar(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	calendarID := request.PathParameters["calendarId"]
 	calendar, err := h.CalendarUsecase.FindCalendar(ctx, calendarID)
-	if err != nil || calendar == nil {
+	if err != nil {
 		return events.APIGatewayProxyResponse{
 			StatusCode: 500,
 			Body:       "Error finding calendar: " + err.Error(),
+		}, nil
+	}
+
+	if calendar == nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: 404,
+			Body:       "Calendar not found",
 		}, nil
 	}
 
@@ -34,10 +41,16 @@ func (h *Handler) HandleGetCalendar(ctx context.Context, request events.APIGatew
 
 func (h *Handler) HandleGetCalendars(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	calendars, err := h.CalendarUsecase.FindCalendars(ctx)
-	if err != nil || calendars == nil {
+	if err != nil {
 		return events.APIGatewayProxyResponse{
 			StatusCode: 500,
 			Body:       "Error finding calendars: " + err.Error(),
+		}, nil
+	}
+	if calendars == nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: 404,
+			Body:       "No calendars found",
 		}, nil
 	}
 	body, err := json.Marshal(calendars)


### PR DESCRIPTION
## 実装の目的/背景

- 非ログイン状態でもカレンダー取得のAPIを叩けるようにする

## 要件・仕様

- 非ログイン状態でもカレンダー取得のAPIを叩けるようにする

## やったこと

- publicpathsに正規表現を入れて、非ログイン状態でもカレンダー取得のAPIを追加
- エラーハンドリングも修正

## 特記 / 特にレビューしてほしい箇所

- とくになし

## 動作確認

- ローカルで確認

## Issues番号

- resolve #57 
