### PR TITLE
Feat/remove idtoken check

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -45,20 +45,20 @@ func (am *authMiddleware) AuthMiddleware(next func(ctx context.Context, request 
 			return unauthorizedResponse("Missing or invalid Authorization header")
 		}
 		accessToken := strings.TrimPrefix(authHeader, "Bearer ")
-		_, err := am.authUsecase.ValidateJWT(accessToken)
+		jwtData, err := am.authUsecase.ValidateJWT(accessToken)
 		if err != nil {
 			return unauthorizedResponse(err.Error())
 		}
 
-		idTokenHeader, ok := request.Headers["X-Id-Token"]
-		if !ok || !strings.HasPrefix(idTokenHeader, "Bearer ") {
-			return unauthorizedResponse("Missing or invalid ID token header")
-		}
-		idToken := strings.TrimPrefix(idTokenHeader, "Bearer ")
-		jwtData, err := am.authUsecase.ValidateJWT(idToken)
-		if err != nil {
-			return unauthorizedResponse(err.Error())
-		}
+		// idTokenHeader, ok := request.Headers["X-Id-Token"]
+		// if !ok || !strings.HasPrefix(idTokenHeader, "Bearer ") {
+		// 	return unauthorizedResponse("Missing or invalid ID token header")
+		// }
+		// idToken := strings.TrimPrefix(idTokenHeader, "Bearer ")
+		// jwtData, err := am.authUsecase.ValidateJWT(idToken)
+		// if err != nil {
+		// 	return unauthorizedResponse(err.Error())
+		// }
 
 		ctx = context.WithValue(ctx, contextKey.JwtDataKey, jwtData)
 

--- a/template.yaml
+++ b/template.yaml
@@ -22,12 +22,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       PackageType: Image
-      Environment:
-        Variables:
-          COGNITO_CLIENT_ID:
-          COGNITO_ISSUER:
-          COGNITO_JWKS_URL:
-          DYNAMODB_ENDPOINT:
       Policies:
         - DynamoDBCrudPolicy:
             TableName: "Calendars"
@@ -52,32 +46,12 @@ Resources:
             Path: /calendar/follow
             Method: PUT
             RestApiId: !Ref BondedApi
-            RequestParameters:
-              - Name: requestBody
-                Required: true
-                Schema:
-                  Type: object
-                  Required:
-                    - calendarId
-                  Properties:
-                    calendarId:
-                      Type: string
         CalendarUnfollow:
           Type: Api
           Properties:
             Path: /calendar/unfollow
             Method: DELETE
             RestApiId: !Ref BondedApi
-            RequestParameters:
-              - Name: requestBody
-                Required: true
-                Schema:
-                  Type: object
-                  Required:
-                    - calendarId
-                  Properties:
-                    calendarId:
-                      Type: string
         CalendarListPublic:
           Type: Api
           Properties:
@@ -132,19 +106,6 @@ Resources:
             Path: /event/delete
             Method: DELETE
             RestApiId: !Ref BondedApi
-            RequestParameters:
-              - Name: requestBody
-                Required: true
-                Schema:
-                  Type: object
-                  Required:
-                    - calendarId
-                    - eventId
-                  Properties:
-                    calendarId:
-                      Type: string
-                    eventId:
-                      Type: string
         EventList:
           Type: Api
           Properties:
@@ -157,37 +118,9 @@ Resources:
             Path: /calendar/user/invite
             Method: POST
             RestApiId: !Ref BondedApi
-            RequestParameters:
-              - Name: requestBody
-                Required: true
-                Schema:
-                  Type: object
-                  Required:
-                    - inviteUserId
-                    - calendarId
-                    - accessLevel
-                  Properties:
-                    inviteUserId:
-                      Type: string
-                    calendarId:
-                      Type: string
-                    accessLevel:
-                      Type: string
-                      Enum:
-                        - EDITOR
-                        - VIEWER
 
     Metadata:
       DockerTag: go-provided.al2-v1
       DockerContext: .
       Dockerfile: Dockerfile
-Outputs:
-  BondedAPI:
-    Description: "API Gateway endpoint URL for Prod environment for Bonded Function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/{proxy+}"
-  BondedFunction:
-    Description: "Bonded Lambda Function ARN"
-    Value: !GetAtt BondedFunction.Arn
-  BondedFunctionIamRole:
-    Description: "Implicit IAM Role created for Bonded function"
-    Value: !GetAtt BondedFunctionRole.Arn
+

--- a/template.yaml
+++ b/template.yaml
@@ -22,6 +22,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       PackageType: Image
+      # Environment:
+      #   Variables:
+      #     COGNITO_CLIENT_ID:
+      #     COGNITO_ISSUER:
+      #     COGNITO_JWKS_URL:
+      #     DYNAMODB_ENDPOINT:
       Policies:
         - DynamoDBCrudPolicy:
             TableName: "Calendars"


### PR DESCRIPTION
## 実装の目的/背景

- API gatewayがカスタムヘッダーをはじいてるっぽい

## 要件・仕様

- idtokeの取得をやめる

## やったこと

- useridはaccesstokenでも取得できるため、idtokeの取得・検証ロジックを丸々コメントアウト

## 特記 / 特にレビューしてほしい箇所

- とくになし

## 動作確認

- ローカル・デプロイ先ともに一応検証済み
