### PR TITLE
fix: カレンダーない状態でも成功ステータスコードを返す

### DIFF
--- a/internal/handler/calendar_impl.go
+++ b/internal/handler/calendar_impl.go
@@ -47,12 +47,6 @@ func (h *Handler) HandleGetCalendars(ctx context.Context, request events.APIGate
 			Body:       "Error finding calendars: " + err.Error(),
 		}, nil
 	}
-	if calendars == nil {
-		return events.APIGatewayProxyResponse{
-			StatusCode: 404,
-			Body:       "No calendars found",
-		}, nil
-	}
 	body, err := json.Marshal(calendars)
 	if err != nil {
 		return events.APIGatewayProxyResponse{


### PR DESCRIPTION
[fix: カレンダーない状態でも成功ステータスコードを返す](https://github.com/Teamsasa/Bonded/pull/63/commits/3415e29fbfcd8d4041fbe723a6e9563d2a7fd575)
calendarがnilのときに、responseはnullになる
フロントエンドの仕様上の修正